### PR TITLE
PSEC-1935

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,132 @@
 
 This project aims to grant assume-role access to an IAM user for a given AWS Role ARN with a time limited IAM policy. 
 
+- [aws-grant-user-access](#aws-grant-user-access)
+  - [CI/CD pipeline](#cicd-pipeline)
+    - [Where can I find a CI/CD pipeline for this code base?](#where-can-i-find-a-cicd-pipeline-for-this-code-base)
+    - [How is the CI/CD pipeline configured?](#how-is-the-cicd-pipeline-configured)
+  - [Setting up locally](#setting-up-locally)
+    - [Running the code: Terragrunt](#running-the-code-terragrunt)
+      - [aws-vault tool](#aws-vault-tool)
+    - [Terraform](#terraform)
+    - [Terragrunt](#terragrunt)
+  - [How do I plan/apply terraform to an environment?](#how-do-i-planapply-terraform-to-an-environment)
+
+## CI/CD pipeline
+
+### Where can I find a CI/CD pipeline for this code base?
+
+- [PR build job](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/638924580364/projects/grant-user-access-pr-builder/history?region=eu-west-2)
+- [Deployment pipeline](https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/grant-user-access-pipeline/view?region=eu-west-2)
+- [Container Release Builder](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/638924580364/projects/grant-user-access-container-release-builder/history?region=eu-west-2) - release changes to `aws_grant_user_access` python code
+
+### How is the CI/CD pipeline configured?
+
+- PR build job is an [AWS CodeBuild](https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/638924580364/projects/grant-user-access-pr-builder/history?region=eu-west-2) project
+- Codepipeline pipeline config for deployment can be found in [here](https://github.com/hmrc/aws-grant-user-access/blob/main/terraform/ci/pipeline/terragrunt.hcl)
+
+## Making Terraform code changes
+
+Remember to run `make tf-fmt` after updating Terraform/Terragrunt files in this repository to fix any styling violations.
+
+See [Setting up locally](#setting-up-locally) section below for relevant tools needed locally. 
+
+## How do I bootstrap an environment for terraform deployment?
+
+```bash
+<ENV>_ACCOUNT_ID=123456789012 \
+  make bootstrap-${ENV}
+```
+
+## How do I plan/apply terraform to an environment?
+
+There is [CI/CD pipeline](#cicd-pipeline) in place to test and apply new changes. However, in the event there is a need to run/test applying terraform resources locally use the command below
+
+```bash
+<ENV>_ACCOUNT_ID=123456789012 \
+  make ${CMD}-${ENV}
+
+# where CMD is one of: validate, plan or apply
+# e.g. LABS_ACCOUNT_ID=123456789012 make plan-labs
+```
+
+## Setting up locally
+
+Pre-requisites:
+- [aws-vault tool](https://github.com/99designs/aws-vault#installing)
+- Terraform
+- Terragrunt
+
+### Running the code: Terragrunt
+
+Before installing or running anything please read this section as it contains important information regarding how we
+execute Terraform.
+
+We use [Terragrunt](#Terragrunt) as our interface to Terraform. Terragrunt is a thin wrapper around Terraform and
+provides several key improvements over using Terraform directly. For example Terragrunt gives us the ability to keep
+code much DRYer than otherwise possible. For more details check out the [Terragrunt website](https://terragrunt.gruntwork.io/).
+By design we *do not* invoke Terraform directly, instead we invoke Terragrunt.
+
+
+#### aws-vault tool
+
+Install [aws-vault tool](https://github.com/99designs/aws-vault#installing).
+
+```bash
+brew install --cask aws-vault
+```
+
+See https://github.com/99designs/aws-vault#installing for installation steps on Linux and Windows
+
+
+#### Terraform
+
+**Install Terraform environment manager**
+
+```bash
+pip install tfenv
+```
+
+Or check https://github.com/tfutils/tfenv#manual
+
+Install Terraform
+
+```bash
+tfenv install
+```
+
+This will install the version of Terraform set in the `.terraform-version` file.
+
+#### Terragrunt
+
+**Install Terragrunt environment manager**
+
+1. Check out tgenv into any path (here is `${HOME}/.tgenv`)
+
+  ```bash
+  git clone https://github.com/cunymatthieu/tgenv.git ~/.tgenv
+  ```
+
+2. Add `~/.tgenv/bin` to your `$PATH` any way you like
+
+  ```bash
+  echo 'export PATH="$HOME/.tgenv/bin:$PATH"' >> ~/.bash_profile
+  ```
+
+  OR you can make symlinks for `tgenv/bin/*` scripts into a path that is already added to your `$PATH` (e.g. `/usr/local/bin`) `OSX/Linux Only!`
+
+  ```bash
+  ln -s ~/.tgenv/bin/* /usr/local/bin
+  ```
+
+**Install Terragrunt**
+
+```bash
+tgenv install
+```
+
+This will install the version of Terragrunt set in the `.terragrunt-version` file.
+
 ## License
 
 This code is open source software licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).

--- a/scripts/apply.sh
+++ b/scripts/apply.sh
@@ -11,6 +11,9 @@ IFS=$'\n\t'
 TARGET=$1
 ASSUME_ROLE_ARN="${TERRAFORM_APPLIER_ROLE_ARN}"
 
+# a simple way to check for presence of *_ACCOUNT_IDS env vars that should be exported by codebuild
+_SUPPORTED_ACCOUNT_IDS="${LABS_ACCOUNT_ID} ${LIVE_ACCOUNT_ID}"
+
 set_aws_credentials() {
 	STS=$(
 		aws sts assume-role \

--- a/scripts/plan.sh
+++ b/scripts/plan.sh
@@ -9,22 +9,25 @@ set -euo pipefail
 IFS=$'\n\t'
 
 TARGET=$1
+case "${TARGET}" in
+labs)
+	ASSUME_ROLE_ARN="${LABS_TERRAFORM_PLANNER_ROLE_ARN}"
+	;;
+live)
+	ASSUME_ROLE_ARN="${LIVE_TERRAFORM_PLANNER_ROLE_ARN}"
+	;;
+*)
+	ASSUME_ROLE_ARN="${LIVE_TERRAFORM_PLANNER_ROLE_ARN}"
+	;;
+esac
+
+# a simple way to check for presence of *_ACCOUNT_IDS env vars that should be exported by codebuild
+_SUPPORTED_ACCOUNT_IDS="${LABS_ACCOUNT_ID} ${LIVE_ACCOUNT_ID}"
 
 set_aws_credentials() {
-	case "${TARGET}" in
-	labs)
-		assume_role_arn="${LABS_TERRAFORM_PLANNER_ROLE_ARN}"
-		;;
-	live)
-		assume_role_arn="${LIVE_TERRAFORM_PLANNER_ROLE_ARN}"
-		;;
-	*)
-		assume_role_arn="${LIVE_TERRAFORM_PLANNER_ROLE_ARN}"
-		;;
-	esac
 	STS=$(
 		aws sts assume-role \
-			--role-arn "${assume_role_arn}" \
+			--role-arn "${ASSUME_ROLE_ARN}" \
 			--role-session-name "${CODEBUILD_INITIATOR#*/}-${CODEBUILD_BUILD_NUMBER}" \
 			--query "Credentials"
 	)

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -45,6 +45,7 @@ paths_have_update() {
 }
 
 main() {
+	echo "Publishing container image to account with ID: ${LIVE_ACCOUNT_ID}"
 	set_aws_credentials
 	IMAGE_TAG="$(git describe --always)-$(date +%Y%m%d%H%M%S)" \
 		make "container-publish"

--- a/terraform/bootstrap/labs/terragrunt.hcl
+++ b/terraform/bootstrap/labs/terragrunt.hcl
@@ -4,7 +4,7 @@ terraform {
 
 locals {
   common                            = read_terragrunt_config(find_in_parent_folders("common/labs.hcl"))
-  account_id                        = local.common.locals.account_id
+  account_id                        = get_env("LABS_ACCOUNT_ID", get_aws_account_id())
   environment                       = local.common.locals.environment
   product                           = local.common.locals.product
   tf_state_bucket_name              = local.common.locals.tf_state_bucket_name
@@ -57,6 +57,7 @@ terraform {
 
 inputs = {
   environment                       = local.environment
+  environment_account_ids           = {}
   log_bucket_name                   = "stackset-access-logs-${local.environment}-${md5(local.environment)}"
   tf_state_bucket_name              = local.tf_state_bucket_name
   tf_state_lock_dynamodb_table_name = local.tf_state_lock_dynamodb_table_name

--- a/terraform/bootstrap/live/terragrunt.hcl
+++ b/terraform/bootstrap/live/terragrunt.hcl
@@ -4,7 +4,7 @@ terraform {
 
 locals {
   common                            = read_terragrunt_config(find_in_parent_folders("common/live.hcl"))
-  account_id                        = local.common.locals.account_id
+  account_id                        = get_env("LIVE_ACCOUNT_ID", get_aws_account_id())
   environment                       = local.common.locals.environment
   product                           = local.common.locals.product
   tf_state_bucket_name              = local.common.locals.tf_state_bucket_name

--- a/terraform/ci/container_release/terragrunt.hcl
+++ b/terraform/ci/container_release/terragrunt.hcl
@@ -5,10 +5,10 @@ terraform {
 locals {
   common          = read_terragrunt_config(find_in_parent_folders("common/live.hcl"))
   product         = local.common.locals.product
-  live_account_id = local.common.locals.account_id
+  live_account_id = get_env("LIVE_ACCOUNT_ID")
 
   labs_common     = read_terragrunt_config(find_in_parent_folders("common/labs.hcl"))
-  labs_account_id = local.labs_common.locals.account_id
+  labs_account_id = get_env("LABS_ACCOUNT_ID")
 }
 
 include {

--- a/terraform/ci/pipeline/terragrunt.hcl
+++ b/terraform/ci/pipeline/terragrunt.hcl
@@ -7,13 +7,13 @@ locals {
   product = local.common.locals.product
 
   labs_common     = read_terragrunt_config(find_in_parent_folders("common/labs.hcl"))
-  labs_account_id = local.labs_common.locals.account_id
+  labs_account_id = get_env("LABS_ACCOUNT_ID")
   labs_admin_roles = {
     "TERRAFORM_APPLIER_ROLE_ARN" = "arn:aws:iam::${local.labs_account_id}:role/RoleTerraformApplier"
     "TERRAFORM_PLANNER_ROLE_ARN" = "arn:aws:iam::${local.labs_account_id}:role/RoleTerraformPlanner"
   }
 
-  live_account_id = local.common.locals.account_id
+  live_account_id = get_env("LIVE_ACCOUNT_ID")
   live_admin_roles = {
     "TERRAFORM_APPLIER_ROLE_ARN" = "arn:aws:iam::${local.live_account_id}:role/RoleTerraformApplier"
     "TERRAFORM_PLANNER_ROLE_ARN" = "arn:aws:iam::${local.live_account_id}:role/RoleTerraformPlanner"

--- a/terraform/ci/pull_request_builder/terragrunt.hcl
+++ b/terraform/ci/pull_request_builder/terragrunt.hcl
@@ -5,10 +5,10 @@ terraform {
 locals {
   common          = read_terragrunt_config(find_in_parent_folders("common/live.hcl"))
   product         = local.common.locals.product
-  live_account_id = local.common.locals.account_id
+  live_account_id = get_env("LIVE_ACCOUNT_ID")
 
   labs_common     = read_terragrunt_config(find_in_parent_folders("common/labs.hcl"))
-  labs_account_id = local.labs_common.locals.account_id
+  labs_account_id = get_env("LABS_ACCOUNT_ID")
 }
 
 include {

--- a/terraform/common/labs.hcl
+++ b/terraform/common/labs.hcl
@@ -1,5 +1,4 @@
 locals {
-  account_id  = "979783897929"
   environment = "labs"
   product     = "grant-user-access"
 

--- a/terraform/common/live.hcl
+++ b/terraform/common/live.hcl
@@ -1,5 +1,4 @@
 locals {
-  account_id  = "638924580364" # auth account
   environment = "live"
   product     = "grant-user-access"
 

--- a/terraform/labs/terragrunt.hcl
+++ b/terraform/labs/terragrunt.hcl
@@ -1,6 +1,5 @@
 locals {
   common      = read_terragrunt_config(find_in_parent_folders("common/labs.hcl"))
-  account_id  = local.common.locals.account_id
   environment = local.common.locals.environment
   product     = local.common.locals.product
 

--- a/terraform/modules/bootstrap/parameter_stores.tf
+++ b/terraform/modules/bootstrap/parameter_stores.tf
@@ -15,3 +15,11 @@ resource "aws_ssm_parameter" "access_log_bucket_id" {
   type        = "String"
   value       = var.log_bucket_name
 }
+
+resource "aws_ssm_parameter" "account_id" {
+  for_each    = var.environment_account_ids
+  name        = "/${each.key}/account_id"
+  description = "AWS Account ID"
+  type        = "String"
+  value       = each.value
+}

--- a/terraform/modules/bootstrap/variables.tf
+++ b/terraform/modules/bootstrap/variables.tf
@@ -4,6 +4,11 @@ variable "environment" {
   description = "Environment name"
 }
 
+variable "environment_account_ids" {
+  type        = map(string)
+  description = "Map of AWS Account ID per environment"
+}
+
 variable "tf_read_roles" {
   type        = list(string)
   description = "A list of roles to allow read access to bucket objects"

--- a/terraform/modules/ci/builder_common/iam.tf
+++ b/terraform/modules/ci/builder_common/iam.tf
@@ -36,6 +36,15 @@ data "aws_iam_policy_document" "build" {
       "${module.builder_bucket.arn}/*/build_outp/*"
     ]
   }
+
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "build" {

--- a/terraform/modules/ci/container_release/buildspecs/release.yaml
+++ b/terraform/modules/ci/container_release/buildspecs/release.yaml
@@ -2,6 +2,8 @@ version: 0.2
 
 env:
   shell: bash
+  parameter-store:
+    LIVE_ACCOUNT_ID: "/live/account_id"
 
 phases:
   build:

--- a/terraform/modules/ci/pipeline/buildspecs/apply.yaml.tpl
+++ b/terraform/modules/ci/pipeline/buildspecs/apply.yaml.tpl
@@ -2,6 +2,9 @@ version: 0.2
 
 env:
   shell: bash
+  parameter-store:
+    LABS_ACCOUNT_ID: "/labs/account_id"
+    LIVE_ACCOUNT_ID: "/live/account_id"
 
 phases:
   build:

--- a/terraform/modules/ci/pull_request_builder/buildspecs/plan.yaml
+++ b/terraform/modules/ci/pull_request_builder/buildspecs/plan.yaml
@@ -2,6 +2,9 @@ version: 0.2
 
 env:
   shell: bash
+  parameter-store:
+    LABS_ACCOUNT_ID: "/labs/account_id"
+    LIVE_ACCOUNT_ID: "/live/account_id"
 
 phases:
   build:

--- a/terraform/modules/ci/terraform_step/iam.tf
+++ b/terraform/modules/ci/terraform_step/iam.tf
@@ -40,6 +40,15 @@ data "aws_iam_policy_document" "build" {
       "${var.s3_bucket_arn}/*/build_outp/*"
     ]
   }
+
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+    resources = [
+      "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/*"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "build" {


### PR DESCRIPTION
Pipeline to source account ID information from ssm parameter store

**Why**
To reduce information a malicious actor can use for reconnaissance given that this is a public repo.