### PR TITLE
PSEC 1922 clean expired policies

### DIFF
--- a/aws_grant_user_access/src/policy_manager.py
+++ b/aws_grant_user_access/src/policy_manager.py
@@ -88,3 +88,18 @@ class PolicyCreator:
         for tag in tag_array:
             tag_dict[tag["Key"]] = tag["Value"]
         return tag_dict
+
+    def get_policy_name(self, policy_arn):
+        policy_details = self.iam_client.get_policy(PolicyArn=policy_arn)
+        return policy_details["Policy"]["PolicyName"]
+
+    def detach_expired_policies_from_users(self, current_time):
+        for policy in self.find_expired_policies(current_time):
+            policy_name = self.get_policy_name(policy_arn=policy)
+            attached_user = policy_name.partition("_")[0]
+            self.iam_client.detach_user_policy(UserName=attached_user, PolicyArn=policy)
+
+    def delete_expired_policies(self, current_time):
+        self.detach_expired_policies_from_users()
+        for policy in self.find_expired_policies(current_time):
+            self.iam_client.delete_policy(policy)

--- a/aws_grant_user_access/src/policy_manager.py
+++ b/aws_grant_user_access/src/policy_manager.py
@@ -100,6 +100,6 @@ class PolicyCreator:
             self.iam_client.detach_user_policy(UserName=attached_user, PolicyArn=policy)
 
     def delete_expired_policies(self, current_time):
-        self.detach_expired_policies_from_users()
+        self.detach_expired_policies_from_users(current_time)
         for policy in self.find_expired_policies(current_time):
-            self.iam_client.delete_policy(policy)
+            self.iam_client.delete_policy(PolicyArn=policy)

--- a/aws_grant_user_access/src/process_event.py
+++ b/aws_grant_user_access/src/process_event.py
@@ -14,11 +14,11 @@ SCHEMA = {
 
 
 def process_event(event, policy_creator):
-    # policy_creator.delete_expired_policies(time_window.start_time)
-
     validate(instance=event, schema=SCHEMA)
+    time_window = GrantTimeWindow(hours=event["approval_in_hours"])
+    policy_creator.delete_expired_policies(current_time=time_window.start_time)
+
     for user in event["username"]:
-        time_window = GrantTimeWindow(hours=event["approval_in_hours"])
         policy_creator.grant_access(
             role_arn=event["role_arn"],
             username=user,

--- a/aws_grant_user_access/src/process_event.py
+++ b/aws_grant_user_access/src/process_event.py
@@ -14,6 +14,8 @@ SCHEMA = {
 
 
 def process_event(event, policy_creator):
+    # policy_creator.delete_expired_policies(time_window.start_time)
+
     validate(instance=event, schema=SCHEMA)
     for user in event["username"]:
         time_window = GrantTimeWindow(hours=event["approval_in_hours"])

--- a/tests/unit/test_lambda_handler.py
+++ b/tests/unit/test_lambda_handler.py
@@ -44,3 +44,13 @@ def test_process_event_creates_iam_policy():
     )
 
     assert 3 == client.grant_access.call_count
+
+
+@freeze_time("2012-01-14 12:00:01")
+def test_process_event_deletes_expired_policies():
+    client = Mock(spec=PolicyCreator)
+    process_event(dict(role_arn=TEST_ROLE_ARN, username=TEST_USERS, approval_in_hours=12), policy_creator=client)
+
+    client.delete_expired_policies.assert_called_once_with(
+        current_time=datetime(year=2012, month=1, day=14, hour=12, minute=0, second=1),
+    )

--- a/tests/unit/test_policy_manager.py
+++ b/tests/unit/test_policy_manager.py
@@ -27,7 +27,6 @@ GET_POLICY = {
     }
 }
 
-
 LIST_POLICIES = {
     "Policies": [
         {
@@ -190,14 +189,17 @@ def test_get_policy_name():
 def test_detach_expired_policies_from_users():
     mock_client = Mock(
         list_policies=Mock(return_value=LIST_POLICIES),
-        get_policy = Mock(return_value=GET_POLICY),
+        get_policy=Mock(return_value=GET_POLICY),
+        detach_user_policy=Mock()
     )
 
-    detached = PolicyCreator(mock_client).detach_expired_policies_from_users(
+    PolicyCreator(mock_client).detach_expired_policies_from_users(
         current_time=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1)
     )
 
-    detached.assert_called_with(
+    mock_client.detach_user_policy.assert_any_call(
         UserName="test-user-3",
         PolicyArn="arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057"
     )
+
+    assert 2 == mock_client.detach_user_policy.call_count

--- a/tests/unit/test_policy_manager.py
+++ b/tests/unit/test_policy_manager.py
@@ -190,7 +190,7 @@ def test_detach_expired_policies_from_users():
     mock_client = Mock(
         list_policies=Mock(return_value=LIST_POLICIES),
         get_policy=Mock(return_value=GET_POLICY),
-        detach_user_policy=Mock()
+        detach_user_policy=Mock(),
     )
 
     PolicyCreator(mock_client).detach_expired_policies_from_users(
@@ -199,7 +199,25 @@ def test_detach_expired_policies_from_users():
 
     mock_client.detach_user_policy.assert_any_call(
         UserName="test-user-3",
-        PolicyArn="arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057"
+        PolicyArn="arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057",
     )
 
     assert 2 == mock_client.detach_user_policy.call_count
+
+
+def test_delete_expired_policies():
+    mock_client = Mock(
+        list_policies=Mock(return_value=LIST_POLICIES),
+        get_policy=Mock(return_value=GET_POLICY),
+        delete_policy=Mock(),
+    )
+
+    PolicyCreator(mock_client).delete_expired_policies(
+        current_time=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1)
+    )
+
+    mock_client.delete_policy.assert_any_call(
+        PolicyArn="arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057"
+    )
+
+    assert 2 == mock_client.delete_policy.call_count

--- a/tests/unit/test_policy_manager.py
+++ b/tests/unit/test_policy_manager.py
@@ -7,6 +7,65 @@ from moto import mock_iam
 
 from aws_grant_user_access.src.policy_manager import PolicyCreator
 
+GET_POLICY = {
+    "Policy": {
+        "PolicyName": "test-user-3_1693482856.642057",
+        "PolicyId": "ABCDEFGHIJKLMNOP01234",
+        "Arn": "arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057",
+        "Path": "/Lambda/GrantUserAccess/",
+        "DefaultVersionId": "v1",
+        "AttachmentCount": 1,
+        "PermissionsBoundaryUsageCount": 0,
+        "IsAttachable": "true",
+        "Description": "An IAM policy to grant-user-access to assume a role",
+        "CreateDate": "2020-05-01T00:00:00+00:00",
+        "UpdateDate": "2020-05-01T00:00:00+00:00",
+        "Tags": [
+            {"Key": "Expires_At", "Value": "2020-05-02T00:00:00+00:00"},
+            {"Key": "Product", "Value": "grant-user-access"},
+        ],
+    }
+}
+
+
+LIST_POLICIES = {
+    "Policies": [
+        {
+            "PolicyName": "test-user-3_1693482856.642057",
+            "Arn": "arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057",
+            "DefaultVersionId": "foo",
+            "Tags": [
+                {"Key": "Expires_At", "Value": "2020-05-01T00:00:00Z"},
+                {"Key": "Product", "Value": "grant-user-access"},
+            ],
+        },
+        {
+            "Arn": "to_keep",
+            "DefaultVersionId": "foo",
+            "Tags": [
+                {"Key": "Expires_At", "Value": "2023-05-01T00:00:00Z"},
+                {"Key": "Product", "Value": "grant-user-access"},
+            ],
+        },
+        {
+            "Arn": "to_keep_2",
+            "DefaultVersionId": "foo",
+            "Tags": [
+                {"Key": "Expires_At", "Value": "2023-05-01T00:00:00Z"},
+            ],
+        },
+        {
+            "PolicyName": "to-delete-also.1693482856.642057",
+            "Arn": "arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/to-delete-also.1693482856.642057",
+            "DefaultVersionId": "foo",
+            "Tags": [
+                {"Key": "Expires_At", "Value": "2021-01-01T01:01:00Z"},
+                {"Key": "Product", "Value": "grant-user-access"},
+            ],
+        },
+    ],
+}
+
 
 def test_policy_creator_generates_policy_document():
     policy_document = PolicyCreator.generate_policy_document(
@@ -105,45 +164,7 @@ def test_policy_is_tagged_with_expiry_time():
 
 def test_find_expired_policies_returns_arns_of_no_longer_needed_policies():
     # using a hand rolled mock here as moto does not return back policy tags
-    mock_client = Mock(
-        list_policies=Mock(
-            return_value={
-                "Policies": [
-                    {
-                        "Arn": "to_delete",
-                        "DefaultVersionId": "foo",
-                        "Tags": [
-                            {"Key": "Expires_At", "Value": "2020-05-01T00:00:00Z"},
-                            {"Key": "Product", "Value": "grant-user-access"},
-                        ],
-                    },
-                    {
-                        "Arn": "to_keep",
-                        "DefaultVersionId": "foo",
-                        "Tags": [
-                            {"Key": "Expires_At", "Value": "2023-05-01T00:00:00Z"},
-                            {"Key": "Product", "Value": "grant-user-access"},
-                        ],
-                    },
-                    {
-                        "Arn": "to_keep_2",
-                        "DefaultVersionId": "foo",
-                        "Tags": [
-                            {"Key": "Expires_At", "Value": "2023-05-01T00:00:00Z"},
-                        ],
-                    },
-                    {
-                        "Arn": "to_delete_also",
-                        "DefaultVersionId": "foo",
-                        "Tags": [
-                            {"Key": "Expires_At", "Value": "2021-01-01T01:01:00Z"},
-                            {"Key": "Product", "Value": "grant-user-access"},
-                        ],
-                    },
-                ],
-            }
-        )
-    )
+    mock_client = Mock(list_policies=Mock(return_value=LIST_POLICIES))
 
     expired = PolicyCreator(mock_client).find_expired_policies(
         current_time=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1)
@@ -151,4 +172,32 @@ def test_find_expired_policies_returns_arns_of_no_longer_needed_policies():
 
     mock_client.list_policies.assert_called_once_with(PathPrefix="/Lambda/GrantUserAccess/")
 
-    assert expired == ["to_delete", "to_delete_also"]
+    assert expired == [
+        "arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057",
+        "arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/to-delete-also.1693482856.642057",
+    ]
+
+
+def test_get_policy_name():
+    mock_client = Mock(get_policy=Mock(return_value=GET_POLICY))
+
+    policy_name = PolicyCreator(mock_client).get_policy_name(
+        policy_arn="arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057"
+    )
+    assert policy_name == "test-user-3_1693482856.642057"
+
+
+def test_detach_expired_policies_from_users():
+    mock_client = Mock(
+        list_policies=Mock(return_value=LIST_POLICIES),
+        get_policy = Mock(return_value=GET_POLICY),
+    )
+
+    detached = PolicyCreator(mock_client).detach_expired_policies_from_users(
+        current_time=datetime(year=2021, month=1, day=1, hour=1, minute=1, second=1)
+    )
+
+    detached.assert_called_with(
+        UserName="test-user-3",
+        PolicyArn="arn:aws:iam::123456789012:policy/Lambda/GrantUserAccess/test-user-3_1693482856.642057"
+    )


### PR DESCRIPTION
- PSEC-1922 added the methods for retrieving policy names from, arn and detaching policies and the tests
- fixed the test for detaching policies from users
- fixed delete policy method and implmented its test
- PSEC-1922 implemented deleting expired policies when the lamda runs
