### PR TITLE
PSEC-1933-enrich-sns-message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ endif
 
 PYTHON_VERSION = $(shell head -1 .python-version)
 PYTHON_COVERAGE_FAIL_UNDER_PERCENT = 100
+PYTHON_SRC = *.py aws_grant_user_access/src/ tests/
 
 POETRY_DOCKER = docker run \
 	--interactive \
@@ -61,10 +62,10 @@ terragrunt:
 		.
 
 fmt:
-	@$(POETRY_DOCKER_MOUNT) black --line-length 120 --exclude=.venv .
+	@$(POETRY_DOCKER_MOUNT) black --line-length 120 --exclude=.venv $(PYTHON_SRC)
 
 fmt-check: build
-	@$(POETRY_DOCKER) black --line-length 120 --check .
+	@$(POETRY_DOCKER) black --line-length 120 --check $(PYTHON_SRC)
 
 python-test: build
 	@$(POETRY_DOCKER) pytest \
@@ -76,10 +77,10 @@ python-test: build
 		tests
 
 mypy: build
-	@$(POETRY_DOCKER) mypy --strict .
+	@$(POETRY_DOCKER) mypy --strict $(PYTHON_SRC)
 
 bandit: build
-	@$(POETRY_DOCKER) bandit -c bandit.yaml -r -q .
+	@$(POETRY_DOCKER) bandit -c bandit.yaml -r -q $(PYTHON_SRC)
 
 
 test: python-test fmt-check md-check mypy bandit

--- a/aws_grant_user_access/src/notifier.py
+++ b/aws_grant_user_access/src/notifier.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from aws_grant_user_access.src.clients.aws_sns_client import AwsSnsClient
 from aws_grant_user_access.src.data.data import AWS_IAM_TIME_FORMAT
 
@@ -12,7 +12,7 @@ class SNSMessage:
         account: str,
         region: str,
         role_arn: str,
-        grantor: str,
+        grantor: Optional[str],
         usernames: List[str],
         hours: int,
         time_window: GrantTimeWindow,

--- a/aws_grant_user_access/src/notifier.py
+++ b/aws_grant_user_access/src/notifier.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, List
 from aws_grant_user_access.src.clients.aws_sns_client import AwsSnsClient
 from aws_grant_user_access.src.data.data import AWS_IAM_TIME_FORMAT
@@ -7,14 +8,17 @@ from aws_grant_user_access.src.grant_time_window import GrantTimeWindow
 
 class SNSMessage:
     @staticmethod
-    def generate(grantor: str, usernames: List[str], role_arn: str, time_window: GrantTimeWindow) -> Dict[str, Any]:
+    def generate(account: str, region: str, role_arn: str, grantor: str, usernames: List[str], hours: int, start_time: datetime, end_time: datetime) -> Dict[str, Any]:
         return {
             "detailType": "GrantUserAccessLambda",
+            "account": account,
+            "region": region,
             "roleArn": role_arn,
             "grantor": grantor,
             "usernames": usernames,
-            "startTime": time_window.start_time.strftime(AWS_IAM_TIME_FORMAT),
-            "endTime": time_window.end_time.strftime(AWS_IAM_TIME_FORMAT),
+            "hours": hours,
+            "startTime": start_time.strftime(AWS_IAM_TIME_FORMAT),
+            "endTime": end_time.strftime(AWS_IAM_TIME_FORMAT),
         }
 
 

--- a/aws_grant_user_access/src/notifier.py
+++ b/aws_grant_user_access/src/notifier.py
@@ -7,18 +7,35 @@ from aws_grant_user_access.src.grant_time_window import GrantTimeWindow
 
 
 class SNSMessage:
-    @staticmethod
-    def generate(account: str, region: str, role_arn: str, grantor: str, usernames: List[str], hours: int, start_time: datetime, end_time: datetime) -> Dict[str, Any]:
+    def __init__(
+        self,
+        account: str,
+        region: str,
+        role_arn: str,
+        grantor: str,
+        usernames: List[str],
+        hours: int,
+        time_window: GrantTimeWindow,
+    ) -> None:
+        self.account = account
+        self.region = region
+        self.role_arn = role_arn
+        self.grantor = grantor
+        self.usernames = usernames
+        self.hours = hours
+        self.time_window = time_window
+
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "detailType": "GrantUserAccessLambda",
-            "account": account,
-            "region": region,
-            "roleArn": role_arn,
-            "grantor": grantor,
-            "usernames": usernames,
-            "hours": hours,
-            "startTime": start_time.strftime(AWS_IAM_TIME_FORMAT),
-            "endTime": end_time.strftime(AWS_IAM_TIME_FORMAT),
+            "account": self.account,
+            "region": self.region,
+            "roleArn": self.role_arn,
+            "grantor": self.grantor,
+            "usernames": self.usernames,
+            "hours": self.hours,
+            "startTime": self.time_window.start_time.strftime(AWS_IAM_TIME_FORMAT),
+            "endTime": self.time_window.end_time.strftime(AWS_IAM_TIME_FORMAT),
         }
 
 

--- a/aws_grant_user_access/src/process_event.py
+++ b/aws_grant_user_access/src/process_event.py
@@ -49,7 +49,7 @@ def process_event(event: Dict[str, Any], context: Any) -> None:
             account=account,
             region=region,
             role_arn=event["role_arn"],
-            grantor=str(None),  # A placeholder until "grantor" is implemented
+            grantor=None,  # A placeholder until "grantor" is implemented
             usernames=event["usernames"],
             hours=int(event["approval_in_hours"]),
             time_window=time_window,

--- a/aws_grant_user_access/src/process_event.py
+++ b/aws_grant_user_access/src/process_event.py
@@ -22,7 +22,7 @@ SCHEMA = {
 config = Config()
 
 
-def process_event(event: Dict[str, Any]) -> None:
+def process_event(event: Dict[str, Any], context: Any) -> None:
     logger = Config.configure_logging()
 
     validate(instance=event, schema=SCHEMA)
@@ -41,19 +41,29 @@ def process_event(event: Dict[str, Any]) -> None:
 
     logger.info(f"Access to {event['role_arn']} granted to {event['usernames']} for {event['approval_in_hours']} hours")
 
-    publish_sns_message(event, time_window)
+    region = context.invoked_function_arn.split(":")[3]
+    account = context.invoked_function_arn.split(":")[4]
+
+    publish_sns_message(
+        message=SNSMessage(
+            account=account,
+            region=region,
+            role_arn=event["role_arn"],
+            grantor="a-platform-owner",
+            usernames=event["usernames"],
+            hours=int(event["approval_in_hours"]),
+            time_window=time_window,
+        )
+    )
 
 
-def publish_sns_message(event: Dict[str, Any], time_window: GrantTimeWindow) -> None:
+def publish_sns_message(message: SNSMessage) -> None:
     try:
         sns_topic_arn = config.get_sns_topic_arn()
     except MissingConfigException as error:
         sns_topic_arn = None
 
     if sns_topic_arn:
-        message = SNSMessage.generate(
-            grantor="", usernames=event["usernames"], role_arn=event["role_arn"], time_window=time_window
-        )
         SNSMessagePublisher(config.get_sns_client()).publish_sns_message(
-            sns_topic_arn=sns_topic_arn, message=json.dumps(message)
+            sns_topic_arn=sns_topic_arn, message=json.dumps(message.to_dict())
         )

--- a/aws_grant_user_access/src/process_event.py
+++ b/aws_grant_user_access/src/process_event.py
@@ -49,7 +49,7 @@ def process_event(event: Dict[str, Any], context: Any) -> None:
             account=account,
             region=region,
             role_arn=event["role_arn"],
-            grantor="a-platform-owner",
+            grantor=str(None),  # A placeholder until "grantor" is implemented
             usernames=event["usernames"],
             hours=int(event["approval_in_hours"]),
             time_window=time_window,

--- a/main.py
+++ b/main.py
@@ -3,4 +3,4 @@ from aws_grant_user_access.src.process_event import process_event
 
 
 def handle(event: Dict[str, Any], context: Any) -> None:
-    process_event(event)
+    process_event(event, context)

--- a/tests/unit/test_notifier.py
+++ b/tests/unit/test_notifier.py
@@ -16,7 +16,7 @@ TEST_ROLE_ARN = "arn:aws:iam::123456789012:role/RoleUserAccess"
 TEST_USERS = ["test-user-1", "test-user-2", "test-user-3"]
 TEST_SNS_MESSAGE = {
     "detailType": "GrantUserAccessLambda",
-    "account": "123456789012", 
+    "account": "123456789012",
     "region": "eu-west-2",
     "roleArn": TEST_ROLE_ARN,
     "grantor": "approval.user",
@@ -46,14 +46,14 @@ def test_publish_sns_message() -> None:
     assert all_send_notifications[0][1] == json.dumps(TEST_SNS_MESSAGE)
 
 
-@freeze_time("2012-06-27 12:00:01")
-def test_generate_message() -> None:
+@freeze_time("2012-01-14 12:00:01")
+def test_sns_message_to_dict() -> None:
     role_arn = "RoleArn"
     grantor = "super.user01"
     usernames = ["test.user01", "test.user02"]
     message = {
         "detailType": "GrantUserAccessLambda",
-        "account": "123456789012", 
+        "account": "123456789012",
         "region": "eu-west-2",
         "roleArn": "arn:aws:iam::123456789012:role/RoleUserAccess",
         "grantor": "super.user01",
@@ -64,15 +64,14 @@ def test_generate_message() -> None:
     }
 
     assert (
-        SNSMessage.generate(
-            account="123456789012", 
+        SNSMessage(
+            account="123456789012",
             region="eu-west-2",
             role_arn="arn:aws:iam::123456789012:role/RoleUserAccess",
             grantor="super.user01",
             usernames=["test.user01", "test.user02"],
             hours=2,
-            start_time=datetime(2012, 1, 14, 12, 0, 1),
-            end_time=datetime(2012, 1, 14, 14, 0, 1)
-        )
+            time_window=GrantTimeWindow(hours=2),
+        ).to_dict()
         == message
     )

--- a/tests/unit/test_notifier.py
+++ b/tests/unit/test_notifier.py
@@ -16,9 +16,12 @@ TEST_ROLE_ARN = "arn:aws:iam::123456789012:role/RoleUserAccess"
 TEST_USERS = ["test-user-1", "test-user-2", "test-user-3"]
 TEST_SNS_MESSAGE = {
     "detailType": "GrantUserAccessLambda",
+    "account": "123456789012", 
+    "region": "eu-west-2",
     "roleArn": TEST_ROLE_ARN,
-    "grantor": "",
+    "grantor": "approval.user",
     "usernames": TEST_USERS,
+    "hours": 1,
     "startTime": "2012-01-14T12:00:01Z",
     "endTime": "2012-01-14T13:00:01Z",
 }
@@ -50,16 +53,26 @@ def test_generate_message() -> None:
     usernames = ["test.user01", "test.user02"]
     message = {
         "detailType": "GrantUserAccessLambda",
-        "roleArn": role_arn,
-        "grantor": grantor,
-        "usernames": usernames,
-        "startTime": "2012-06-27T12:00:01Z",
-        "endTime": "2012-06-27T14:00:01Z",
+        "account": "123456789012", 
+        "region": "eu-west-2",
+        "roleArn": "arn:aws:iam::123456789012:role/RoleUserAccess",
+        "grantor": "super.user01",
+        "usernames": ["test.user01", "test.user02"],
+        "hours": 2,
+        "startTime": "2012-01-14T12:00:01Z",
+        "endTime": "2012-01-14T14:00:01Z",
     }
 
     assert (
         SNSMessage.generate(
-            grantor=grantor, usernames=usernames, role_arn=role_arn, time_window=GrantTimeWindow(hours=2)
+            account="123456789012", 
+            region="eu-west-2",
+            role_arn="arn:aws:iam::123456789012:role/RoleUserAccess",
+            grantor="super.user01",
+            usernames=["test.user01", "test.user02"],
+            hours=2,
+            start_time=datetime(2012, 1, 14, 12, 0, 1),
+            end_time=datetime(2012, 1, 14, 14, 0, 1)
         )
         == message
     )


### PR DESCRIPTION
Add extra info in SNS message

**Why?**
'account' and 'region' information is expected by platsec-compliance-alerting