### PR TITLE
INFRA-8510. Allow GrantUserAccessLambda to grant RoleInfrastructureAdministrator

### DIFF
--- a/aws_grant_user_access/src/process_event.py
+++ b/aws_grant_user_access/src/process_event.py
@@ -18,6 +18,7 @@ PERMITTED_ROLES = [
     "RoleStacksetAdministrator",
     "RoleSSMAccess",
     "RoleCredentialsRotation",
+    "RoleInfrastructureAdministrator",
 ]
 
 ONE_WEEK = 168


### PR DESCRIPTION
This PR give the GrantUserAccessLambda used by Platform Owners the ability to grant access to the role : RoleInfrastructureAdministrator 